### PR TITLE
Airsim receiver can accept pose messages from more than one gazebo instance

### DIFF
--- a/pose/gazebo/gazebo_drone_pose/gazebo_drone_pose.hpp
+++ b/pose/gazebo/gazebo_drone_pose/gazebo_drone_pose.hpp
@@ -32,12 +32,14 @@ class GenerateCbLocalPose {
     private:
         PoseSender* poseSender;
         std::unordered_map<std::string, uint16_t> droneIds;
+        std::unordered_map<std::string, uint64_t> messageCount;
         uint16_t uniqueDroneCount = 0;
         /**
          * gives a single unique uint16_t id to each unique drone name provided
          * @param droneName unique name of a drone
         */
         void trackDroneIds(std::string droneName);
+        uint64_t getMessageCount(std::string droneName);
 };
 
 #endif


### PR DESCRIPTION
airsim receiver can accept pose messages from more than one gazebo instance
Fixes #35
To implement this we need to:
- Maintain a unique message count for each drone
- Use a unique drone ID across all gazebo instances

So every time we send a pose message for the "red" drone, we must number each message, starting at 1, then counting up by one for each subsequent message.

And every time we send a pose message for the "blue" drone, we will do the same thing, starting at one, and counting up by one each time.

Please note our drones are "named" using a 16bit integer, but the concept still applies.